### PR TITLE
glen-flask-init: Fix oauth route and add some "GET" handling.

### DIFF
--- a/tesla/app.py
+++ b/tesla/app.py
@@ -3,7 +3,7 @@ from flask_socketio import SocketIO
 from flask.ext.cors import CORS
 
 from config import Config
-from api import blue_api
+from api import blue_api, auth_api
 from views import blue_views
 
 
@@ -23,6 +23,7 @@ def create_app():
 
     app.config.from_object(Config())
     with app.app_context():
+        app.register_blueprint(auth_api, url_prefix='')
         app.register_blueprint(blue_api, url_prefix='/api/1')
         app.register_blueprint(blue_views, url_prefix='/')
 


### PR DESCRIPTION
QDH to fudge the route for oauth/token as this doesn't have
the same prefix as other API routes - this will be
same for Mobile Access
(http://docs.timdorr.apiary.io/#reference/vehicles/state-and-settings/mobile-access)

Make the POST route (commands/) handle various commands which are in our
valid list.  We may need to further validate params in future.

Add a GET route (data_request/) to handle some requests and
return prepopulated responses - can be "randomised" later.
